### PR TITLE
adds stroke-dasharray to create pixelate effect

### DIFF
--- a/hex.css
+++ b/hex.css
@@ -120,11 +120,14 @@ circle {
   animation-fill-mode: forwards;
   animation-timing-function: ease-in-out;
   fill: var(--palette-hue1-luminance4);
+  shape-rendering: 'crispEdges';
+  stroke: var(--palette-hue1-luminance4);
+  stroke-dasharray: 6 2;
+  stroke-width: 1;
 }
 
 #main circle {
-  r: 0;
-  opacity: 1;
+  opacity: 0.85;
   animation-name: bob-out;
 }
 
@@ -182,17 +185,17 @@ circle {
   cursor: pointer;
 }
 
-.p0 circle { fill: var(--palette-hue3-luminance8); }
-.p1 circle { fill: var(--palette-hue4-luminance8); }
-.p2 circle { fill: var(--palette-hue5-luminance8); }
-.p3 circle { fill: var(--palette-hue6-luminance8); }
-.p4 circle { fill: var(--palette-hue7-luminance8); }
-.p5 circle { fill: var(--palette-hue8-luminance8); }
-.p6 circle { fill: var(--palette-hue9-luminance8); }
-.p7 circle { fill: var(--palette-hue10-luminance8); }
-.p8 circle { fill: var(--palette-hue11-luminance8); }
+.p0 circle { fill: var(--palette-hue3-luminance8); stroke: var(--palette-hue3-luminance8); }
+.p1 circle { fill: var(--palette-hue4-luminance8); stroke: var(--palette-hue4-luminance8); }
+.p2 circle { fill: var(--palette-hue5-luminance8); stroke: var(--palette-hue5-luminance8); }
+.p3 circle { fill: var(--palette-hue6-luminance8); stroke: var(--palette-hue6-luminance8); }
+.p4 circle { fill: var(--palette-hue7-luminance8); stroke: var(--palette-hue7-luminance8); }
+.p5 circle { fill: var(--palette-hue8-luminance8); stroke: var(--palette-hue8-luminance8); }
+.p6 circle { fill: var(--palette-hue9-luminance8); stroke: var(--palette-hue9-luminance8); }
+.p7 circle { fill: var(--palette-hue10-luminance8); stroke: var(--palette-hue10-luminance8); }
+.p8 circle { fill: var(--palette-hue11-luminance8); stroke: var(--palette-hue11-luminance8); }
 
-.menu .hex:hover circle { fill: var(--palette-hue2-luminance8); }
+.menu .hex:hover circle { fill: var(--palette-hue2-luminance8); stroke: var(--palette-hue2-luminance8); }
 
 @keyframes bob {
   0%   { opacity: 1;   }

--- a/hex.svg
+++ b/hex.svg
@@ -9,15 +9,15 @@
     <g id="board">
       <g id="orig" class="hex zero init" transform-origin="0 0">
         <path class="hexagon" d="M0 50l25 43.3l50 0L100 50L75 6.7l-50 0z"/>
-        <circle r="7" class="one three five seven nine" cx="50" cy="50"/>
-        <circle r="7" class="two three four five six seven eight nine" cx="33.33" cy="33.33"/>
-        <circle r="7" class="two three four five six seven eight nine" cx="66.66" cy="66.66"/>
-        <circle r="7" class="four five six seven eight nine" cx="33.33" cy="66.66"/>
-        <circle r="7" class="four five six seven eight nine" cx="66.66" cy="33.33"/>
-        <circle r="7" class="six seven eight nine" cx="33.33" cy="50"/>
-        <circle r="7" class="six seven eight nine" cx="66.66" cy="50"/>
-        <circle r="7" class="eight nine" cx="50" cy="33.33"/>
-        <circle r="7" class="eight nine" cx="50" cy="66.66"/>
+        <circle r="3" class="one three five seven nine" cx="50" cy="50"/>
+        <circle r="3" class="two three four five six seven eight nine" cx="33.33" cy="33.33"/>
+        <circle r="3" class="two three four five six seven eight nine" cx="66.66" cy="66.66"/>
+        <circle r="3" class="four five six seven eight nine" cx="33.33" cy="66.66"/>
+        <circle r="3" class="four five six seven eight nine" cx="66.66" cy="33.33"/>
+        <circle r="3" class="six seven eight nine" cx="33.33" cy="50"/>
+        <circle r="3" class="six seven eight nine" cx="66.66" cy="50"/>
+        <circle r="3" class="eight nine" cx="50" cy="33.33"/>
+        <circle r="3" class="eight nine" cx="50" cy="66.66"/>
       </g>
     </g>
   </g>


### PR DESCRIPTION
## 🖼 Description
Apparently filters are quite heavy on bigger boards they slow down the animations so I found this usage of a dashed border could make the eye trick 👾 

## 🎨 GIFs
![pixelate](https://user-images.githubusercontent.com/3428837/51433170-d80f2f00-1c3c-11e9-9e5c-0a9a6cad3deb.gif)
